### PR TITLE
use new LTS CloudStack v4.11.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER "René Moser" <mail@renemoser.net>
 RUN echo 'mysql-server mysql-server/root_password password root' | debconf-set-selections; \
     echo 'mysql-server mysql-server/root_password_again password root' | debconf-set-selections;
 
-RUN apt-get -y update && apt-get install -y \
+RUN apt-get -y update && apt-get dist-upgrade -y && apt-get install -y \
     genisoimage \
     libffi-dev \
     libssl-dev \
@@ -38,7 +38,7 @@ RUN mkdir -p /var/run/mysqld; \
 
 RUN (/usr/bin/mysqld_safe &); sleep 5; mysqladmin -u root -proot password ''
 
-RUN wget https://github.com/apache/cloudstack/archive/4.9.2.0.tar.gz -O /opt/cloudstack.tar.gz; \
+RUN wget https://github.com/apache/cloudstack/archive/4.11.1.0.tar.gz -O /opt/cloudstack.tar.gz; \
     mkdir -p /opt/cloudstack; \
     tar xvzf /opt/cloudstack.tar.gz -C /opt/cloudstack --strip-components=1
 
@@ -57,9 +57,12 @@ RUN (/usr/bin/mysqld_safe &); \
 
 COPY zones.cfg /opt/zones.cfg
 COPY nginx_default.conf /etc/nginx/sites-available/default
-RUN pip install cs==1.1.1
+RUN pip install cs==2.3.1
 COPY run.sh /opt/run.sh
+COPY deploy.sh /opt/deploy.sh
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+RUN /opt/deploy.sh
 
 EXPOSE 8888 8080 8096
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM ubuntu:16.04
 
 MAINTAINER "René Moser" <mail@renemoser.net>
 
+ARG src_url=https://github.com/apache/cloudstack/archive/4.11.1.0.tar.gz
+
 RUN echo 'mysql-server mysql-server/root_password password root' | debconf-set-selections; \
     echo 'mysql-server mysql-server/root_password_again password root' | debconf-set-selections;
 
@@ -38,7 +40,7 @@ RUN mkdir -p /var/run/mysqld; \
 
 RUN (/usr/bin/mysqld_safe &); sleep 5; mysqladmin -u root -proot password ''
 
-RUN wget https://github.com/apache/cloudstack/archive/4.11.1.0.tar.gz -O /opt/cloudstack.tar.gz; \
+RUN wget $src_url -O /opt/cloudstack.tar.gz; \
     mkdir -p /opt/cloudstack; \
     tar xvzf /opt/cloudstack.tar.gz -C /opt/cloudstack --strip-components=1
 

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 build:
-	docker build -t cloudstack-sim .
+	docker build --no-cache -t cloudstack-sim .
 
 clean:
-	docker rm -f cloudstack
+	docker rm -f cloudstack-sim
 
 run:
-	docker run --name cloudstack -d -p 8080:8080 -p 8888:8888 cloudstack-sim
+	docker run --name cloudstack-sim -d -p 8080:8080 -p 8888:8888 cloudstack-sim
 
 shell:
-	docker exec -it cloudstack /bin/bash
+	docker exec -it cloudstack-sim /bin/bash
 
 logs:
-	docker logs -f cloudstack
+	docker logs -f cloudstack-sim

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,12 @@
+#!/bin/bash +x
+
+/usr/bin/mysqld_safe &
+cd /opt/cloudstack && mvn -pl client jetty:run -Dsimulator -Dorg.eclipse.jetty.annotations.maxWait=120 &
+
+until nc -z localhost 8096; do
+    echo "waiting for port 8096..."
+    sleep 3
+done
+
+sleep 3
+python /opt/cloudstack/tools/marvin/marvin/deployDataCenter.py -i /opt/zones.cfg

--- a/run.sh
+++ b/run.sh
@@ -7,9 +7,9 @@ done
 sleep 3
 if [ ! -e /var/www/html/admin.json ]
 then
-  python /opt/cloudstack/tools/marvin/marvin/deployDataCenter.py -i /opt/zones.cfg
   export CLOUDSTACK_ENDPOINT=http://127.0.0.1:8096
   export CLOUDSTACK_KEY=""
   export CLOUDSTACK_SECRET=""
-  cs listUsers account=admin | jq .user[0] > /var/www/html/admin.json
+  admin_id="$(cs listUsers account=admin | jq .user[0].id)"
+  cs getUserKeys id=$admin_id | jq .userkeys > /var/www/html/admin.json
 fi

--- a/run.sh
+++ b/run.sh
@@ -10,6 +10,11 @@ then
   export CLOUDSTACK_ENDPOINT=http://127.0.0.1:8096
   export CLOUDSTACK_KEY=""
   export CLOUDSTACK_SECRET=""
+
+  # Workaround for Nuage VPC Offering
+  vpc_offering_id="$(cs listVPCOfferings listall=true name=Nuage | jq .vpcoffering[0].id)"
+  cs updateVPCOffering id=$vpc_offering_id state=Disabled
+
   admin_id="$(cs listUsers account=admin | jq .user[0].id)"
   cs getUserKeys id=$admin_id | jq .userkeys > /var/www/html/admin.json
 fi

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -8,7 +8,7 @@ autorestart=true
 user=root
 
 [program:cloudstack]
-command=/bin/bash -c "mvn -pl client jetty:run-forked -Dsimulator -Dorg.eclipse.jetty.annotations.maxWait=120"
+command=/bin/bash -c "mvn -pl client jetty:run -Dsimulator -Dorg.eclipse.jetty.annotations.maxWait=120"
 directory=/opt/cloudstack
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
@@ -20,9 +20,9 @@ autostart=true
 autorestart=false
 user=root
 
-[program:deploy-zones]
-command = /opt/run.sh
-startsecs = 0
-autorestart = false
-startretries = 1
+[program:run]
+command=/opt/run.sh
+startsecs=0
+autorestart=false
+startretries=1
 user=root

--- a/zones.cfg
+++ b/zones.cfg
@@ -288,11 +288,7 @@
         },
         {
             "name": "ping.timeout",
-            "value": "1.5"
-        },
-        {
-            "name": "outofbandmanagement.sync.interval",
-            "value": "1000"
+            "value": "2"
         }
     ],
     "mgtSvr": [


### PR DESCRIPTION
CloudStack v4.9 is EOL. Updated to new LTS and dramaticially reduced startup time to seconds rather than mintues.

CloudStack tests does not fully pass yet because of some changes in API returns. Do not merge yet.

/cc @mattclay @gundalow 