### PR TITLE
Upgrades to cloudstack 4.13 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:xenial-20181113
 
 MAINTAINER "René Moser" <mail@renemoser.net>
 
-ARG src_url=https://github.com/apache/cloudstack/archive/4.11.2.0.tar.gz
+ARG src_url=https://github.com/apache/cloudstack/archive/4.13.1.0.tar.gz
 
 RUN echo 'mysql-server mysql-server/root_password password root' | debconf-set-selections; \
     echo 'mysql-server mysql-server/root_password_again password root' | debconf-set-selections;
@@ -20,6 +20,7 @@ RUN apt-get -y update && apt-get dist-upgrade -y && apt-get install -y \
     python-mysql.connector \
     python-pip \
     python-setuptools \
+    python-paramiko \
     supervisor \
     wget \
     nginx \

--- a/deploy.sh
+++ b/deploy.sh
@@ -18,6 +18,3 @@ export CLOUDSTACK_SECRET=dummy
 # Add Simulator to supported hypervisors exclusively
 cs updateConfiguration name=hypervisor.list value=Simulator
 
-# Workaround for Nuage VPC Offering
-vpc_offering_id="$(cs listVPCOfferings name=Nuage | jq '.vpcoffering[0].id')"
-cs updateVPCOffering id=$vpc_offering_id state=Disabled


### PR DESCRIPTION
The last stage to the Dockerfile is complaining about python cryptography package no longer being supported for python 2.

This PR installs paramiko as an ubuntu package, which stops the requirement from installing later on in the process (possibly from a python requirement file)

However this PR is still not functional because now there is a failure which seems to be under the domain of the application, instead of a mere compilation issue.

```
====Deploy DC Successful=====
{
  "configuration": {
    "category": "Advanced", 
    "description": "The list of hypervisors that this deployment will use.", 
    "isdynamic": false, 
    "name": "hypervisor.list", 
    "value": "Simulator"
  }
}
INFO  [c.c.a.ApiServer] (ApiServer-5:ctx-fd31a206 ctx-9a1c4aeb) (logid:e0645bb7) Unable to execute API command updatevpcoffering due to invalid value. Invalid parameter id value= due to incorrect long value format, or entity does not exist or due to incorrect parameter annotation for the field in api cmd class.
Cloudstack error: HTTP response 431
{
  "updatevpcofferingresponse": {
    "cserrorcode": 9999, 
    "errorcode": 431, 
    "errortext": "Unable to execute API command updatevpcoffering due to invalid value. Invalid parameter id value= due to incorrect long value format, or entity does not exist or due to incorrect parameter annotation for the field in api cmd class.", 
    "uuidList": []
  }
}
The command '/bin/sh -c /opt/deploy.sh' returned a non-zero code: 1
```

@resmo do you have any idea what this error could be about?

Resolves #11