### PR TITLE
new upstream 4.18.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/bedrock/ubuntu:22.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
-ARG src_url=https://github.com/apache/cloudstack/archive/refs/tags/4.17.2.0.tar.gz
+ARG src_url=https://github.com/apache/cloudstack/archive/refs/tags/4.18.0.0.tar.gz
 
 RUN echo 'mysql-server mysql-server/root_password password root' | debconf-set-selections; \
     echo 'mysql-server mysql-server/root_password_again password root' | debconf-set-selections;
@@ -32,7 +32,6 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends \
     npm \
     nodejs \
     && apt-get clean all && rm -rf /var/lib/apt/lists/*;
-
 
 # TODO: check if and why this is needed
 RUN mkdir -p /root/.ssh \


### PR DESCRIPTION
@mattclay New upstream release of cloudstack 4.18.0 LTS

/cc @rvalle 